### PR TITLE
feat(agent): add MCP verification at container startup

### DIFF
--- a/compose/compose.persistent.yml
+++ b/compose/compose.persistent.yml
@@ -51,7 +51,8 @@ services:
     # Direct mount: host project directory -> /project (RW)
     volumes:
       - ${PROJECT_PATH:-./../project}:/project:rw
-    
+      - ../secrets:/secrets:ro
+
     # Security hardening
     read_only: true
     tmpfs:

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -108,8 +108,10 @@ COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY scripts/setup-git-pat.sh /opt/scripts/setup-git-pat.sh
 COPY scripts/setup-github-app.sh /opt/scripts/setup-github-app.sh
 COPY scripts/clone-repo.sh /opt/scripts/clone-repo.sh
+COPY scripts/verify-mcp.sh /opt/scripts/verify-mcp.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh /opt/scripts/setup-git-pat.sh \
-    /opt/scripts/setup-github-app.sh /opt/scripts/clone-repo.sh
+    /opt/scripts/setup-github-app.sh /opt/scripts/clone-repo.sh \
+    /opt/scripts/verify-mcp.sh
 
 # Copy config files last (they change most frequently)
 # This minimizes cache invalidation when only config changes

--- a/image/config/sandbox-context.md
+++ b/image/config/sandbox-context.md
@@ -937,6 +937,49 @@ Prefer MCP tools over CLI commands:
 
 ## Troubleshooting
 
+### Verify MCP is Working
+
+**First step for any MCP issues:** Run the verification script:
+
+```bash
+# Quick verification
+/opt/scripts/verify-mcp.sh
+
+# Verbose output (shows more details)
+GITHUB_DEBUG=1 /opt/scripts/verify-mcp.sh --verbose
+
+# Test access to a specific repo
+GITHUB_VERIFY_REPO=owner/repo /opt/scripts/verify-mcp.sh
+```
+
+The script checks:
+- ✓ MCP configuration exists in settings.json
+- ✓ GitHub token is present and valid
+- ✓ Token has correct permissions
+- ✓ Environment variables are set for gh CLI
+
+### MCP Tools Not Available
+
+If MCP tools aren't working:
+
+1. **Check if MCP server is configured:**
+   ```bash
+   cat ~/.claude/settings.json | jq .mcpServers
+   ```
+   Should show a `github` object with command and token.
+
+2. **Verify token is valid:**
+   ```bash
+   TOKEN=$(cat ~/.claude/settings.json | jq -r '.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN')
+   curl -H "Authorization: Bearer $TOKEN" https://api.github.com/rate_limit
+   ```
+
+3. **Fallback to gh CLI with explicit token:**
+   ```bash
+   TOKEN=$(cat ~/.claude/settings.json | jq -r '.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN')
+   GH_TOKEN=$TOKEN gh pr create --title "..." --body "..."
+   ```
+
 ### MCP Tool Failures
 
 | Error | Cause | Solution |
@@ -945,6 +988,7 @@ Prefer MCP tools over CLI commands:
 | "Resource not accessible" | Permission issue | Check if repo is private; token may lack access |
 | "Validation Failed" | Missing required fields | Check all required parameters are provided |
 | Push/PR creation fails | Branch protection or conflict | Pull latest main, rebase your branch |
+| "MCP tools not available" | Server not running | Run `/opt/scripts/verify-mcp.sh --verbose` |
 
 ### Network Issues
 

--- a/image/scripts/entrypoint.sh
+++ b/image/scripts/entrypoint.sh
@@ -97,6 +97,24 @@ if command -v gh >/dev/null 2>&1; then
     gh config set git_protocol https --host github.com 2>/dev/null || true
 fi
 
+# Verify MCP configuration if GitHub auth was set up
+if [[ -n "${GITHUB_TOKEN:-}" ]] || [[ -n "${GH_TOKEN:-}" ]]; then
+    if [[ -f /opt/scripts/verify-mcp.sh ]]; then
+        echo "" >&2
+        if [[ "${GITHUB_DEBUG:-}" == "1" ]]; then
+            /opt/scripts/verify-mcp.sh --verbose || {
+                echo "WARNING: MCP verification failed, some GitHub features may not work" >&2
+            }
+        else
+            /opt/scripts/verify-mcp.sh || {
+                echo "WARNING: MCP verification failed, some GitHub features may not work" >&2
+                echo "  Run with GITHUB_DEBUG=1 for details" >&2
+            }
+        fi
+        echo "" >&2
+    fi
+fi
+
 # Execute the provided command or default to bash
 exec "$@"
 

--- a/image/scripts/verify-mcp.sh
+++ b/image/scripts/verify-mcp.sh
@@ -1,0 +1,309 @@
+#!/bin/bash
+# verify-mcp.sh - Verify MCP GitHub integration is working
+#
+# This script verifies that:
+# 1. settings.json has MCP configuration
+# 2. GitHub token is present and valid
+# 3. Token has correct permissions for the target repo
+#
+# Usage:
+#   /opt/scripts/verify-mcp.sh [--verbose]
+#
+# Environment:
+#   GITHUB_VERIFY_REPO  - Optional: repo to verify access to (owner/repo)
+#   GITHUB_DEBUG        - Set to "1" for verbose output
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - Configuration error (missing settings, invalid JSON)
+#   2 - Token error (missing, expired, or invalid)
+#   3 - Permission error (can't access required resources)
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+VERBOSE="${GITHUB_DEBUG:-0}"
+if [[ "${1:-}" == "--verbose" ]]; then
+    VERBOSE="1"
+fi
+
+# Track overall status
+STATUS=0
+WARNINGS=0
+
+log_ok() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}⚠${NC} $1" >&2
+    WARNINGS=$((WARNINGS + 1))
+}
+
+log_fail() {
+    echo -e "${RED}✗${NC} $1" >&2
+}
+
+log_debug() {
+    if [[ "$VERBOSE" == "1" ]]; then
+        echo -e "  ${1}" >&2
+    fi
+}
+
+# Check 1: settings.json exists and has MCP config
+check_settings() {
+    local settings_file="${HOME}/.claude/settings.json"
+    
+    if [[ ! -f "$settings_file" ]]; then
+        log_fail "Settings file not found: $settings_file"
+        return 1
+    fi
+    
+    # Verify it's valid JSON
+    if ! jq empty "$settings_file" 2>/dev/null; then
+        log_fail "Settings file is not valid JSON"
+        return 1
+    fi
+    
+    # Check for mcpServers.github
+    local has_github
+    has_github=$(jq -r '.mcpServers.github // empty' "$settings_file")
+    
+    if [[ -z "$has_github" ]]; then
+        log_fail "No MCP GitHub server configured in settings.json"
+        log_debug "Expected: .mcpServers.github object"
+        return 1
+    fi
+    
+    # Check for token in MCP config
+    local token
+    token=$(jq -r '.mcpServers.github.env.GITHUB_PERSONAL_ACCESS_TOKEN // empty' "$settings_file")
+    
+    if [[ -z "$token" ]]; then
+        log_fail "No GitHub token in MCP configuration"
+        return 1
+    fi
+    
+    # Mask token for display
+    local token_preview="${token:0:10}...${token: -4}"
+    log_ok "MCP config found with token: ${token_preview}"
+    
+    # Export for later checks
+    export MCP_TOKEN="$token"
+    return 0
+}
+
+# Check 2: Token is valid (not expired)
+check_token_valid() {
+    local token="${MCP_TOKEN:-}"
+    
+    if [[ -z "$token" ]]; then
+        log_fail "No token available for validation"
+        return 2
+    fi
+    
+    # Test token with a simple API call
+    local response
+    local http_code
+    
+    response=$(curl -s -w "\n%{http_code}" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/user" 2>/dev/null)
+    
+    http_code=$(echo "$response" | tail -1)
+    local body
+    body=$(echo "$response" | sed '$d')
+    
+    case "$http_code" in
+        200)
+            local login
+            login=$(echo "$body" | jq -r '.login // "unknown"')
+            log_ok "Token valid - authenticated as: ${login}"
+            return 0
+            ;;
+        401)
+            log_fail "Token is invalid or expired"
+            log_debug "HTTP 401: Bad credentials"
+            return 2
+            ;;
+        403)
+            # Installation tokens return 403 for /user but may still work for repo operations
+            # Try to get rate limit info instead
+            local rate_response
+            rate_response=$(curl -s \
+                -H "Authorization: Bearer ${token}" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/rate_limit" 2>/dev/null)
+            
+            local remaining
+            remaining=$(echo "$rate_response" | jq -r '.rate.remaining // 0')
+            
+            if [[ "$remaining" -gt 0 ]]; then
+                log_ok "Token valid (installation token) - rate limit remaining: ${remaining}"
+                return 0
+            else
+                log_fail "Token rejected (HTTP 403)"
+                return 2
+            fi
+            ;;
+        *)
+            log_warn "Unexpected response (HTTP ${http_code})"
+            log_debug "Response: ${body}"
+            return 2
+            ;;
+    esac
+}
+
+# Check 3: Can access target repository (if specified)
+check_repo_access() {
+    local repo="${GITHUB_VERIFY_REPO:-}"
+    local token="${MCP_TOKEN:-}"
+    
+    if [[ -z "$repo" ]]; then
+        log_debug "GITHUB_VERIFY_REPO not set, skipping repo access check"
+        return 0
+    fi
+    
+    if [[ -z "$token" ]]; then
+        log_warn "No token for repo access check"
+        return 0
+    fi
+    
+    local response
+    local http_code
+    
+    response=$(curl -s -w "\n%{http_code}" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "https://api.github.com/repos/${repo}" 2>/dev/null)
+    
+    http_code=$(echo "$response" | tail -1)
+    local body
+    body=$(echo "$response" | sed '$d')
+    
+    case "$http_code" in
+        200)
+            local permissions
+            permissions=$(echo "$body" | jq -r '.permissions | to_entries | map(select(.value == true) | .key) | join(", ")' 2>/dev/null || echo "unknown")
+            log_ok "Repository access: ${repo} (${permissions})"
+            return 0
+            ;;
+        404)
+            log_fail "Repository not found or no access: ${repo}"
+            return 3
+            ;;
+        403)
+            log_fail "Permission denied for repository: ${repo}"
+            return 3
+            ;;
+        *)
+            log_warn "Unexpected response for repo check (HTTP ${http_code})"
+            return 3
+            ;;
+    esac
+}
+
+# Check 4: Environment variables are exported (for gh CLI)
+check_env_vars() {
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        log_ok "GITHUB_TOKEN environment variable is set"
+    else
+        log_warn "GITHUB_TOKEN not set in environment (gh CLI may not work)"
+    fi
+    
+    if [[ -n "${GH_TOKEN:-}" ]]; then
+        log_ok "GH_TOKEN environment variable is set"
+    else
+        log_warn "GH_TOKEN not set in environment (gh CLI may not work)"
+    fi
+    
+    return 0
+}
+
+# Check 5: MCP server can be started (optional, heavier check)
+check_mcp_server_startup() {
+    if [[ "$VERBOSE" != "1" ]]; then
+        return 0
+    fi
+    
+    if ! command -v npx >/dev/null 2>&1; then
+        log_warn "npx not available, cannot test MCP server startup"
+        return 0
+    fi
+    
+    log_debug "Testing MCP server startup (this may take a moment)..."
+    
+    # Try to start the MCP server and immediately send a tool list request
+    # The server should respond with available tools
+    if ! command -v timeout >/dev/null 2>&1; then
+        # macOS doesn't have timeout by default
+        log_debug "timeout command not available, skipping MCP server test"
+        return 0
+    fi
+    
+    # Start MCP server with token, capture output
+    local token="${MCP_TOKEN:-}"
+    local output
+    output=$(GITHUB_PERSONAL_ACCESS_TOKEN="$token" timeout 10 npx -y @github/github-mcp-server 2>&1 || true)
+    
+    if echo "$output" | grep -qi "error\|failed\|cannot"; then
+        log_warn "MCP server startup may have issues"
+        log_debug "Output: ${output:0:200}..."
+    else
+        log_ok "MCP server startup check passed"
+    fi
+    
+    return 0
+}
+
+# Main
+main() {
+    echo "=== MCP GitHub Integration Verification ==="
+    echo ""
+    
+    # Run checks
+    if ! check_settings; then
+        STATUS=1
+    fi
+    
+    if [[ $STATUS -eq 0 ]]; then
+        if ! check_token_valid; then
+            STATUS=2
+        fi
+    fi
+    
+    if [[ $STATUS -eq 0 ]]; then
+        if ! check_repo_access; then
+            STATUS=3
+        fi
+    fi
+    
+    check_env_vars
+    check_mcp_server_startup
+    
+    echo ""
+    
+    # Summary
+    if [[ $STATUS -eq 0 ]]; then
+        if [[ $WARNINGS -gt 0 ]]; then
+            echo -e "${YELLOW}MCP verification completed with ${WARNINGS} warning(s)${NC}"
+        else
+            echo -e "${GREEN}MCP verification passed${NC}"
+        fi
+    else
+        echo -e "${RED}MCP verification failed (exit code: ${STATUS})${NC}"
+    fi
+    
+    return $STATUS
+}
+
+main "$@"
+


### PR DESCRIPTION
## Summary

Adds startup verification to confirm MCP GitHub integration is working properly, addressing the intermittent MCP tool availability issues documented in the logs.

## Problem

The sandboxed agent was experiencing intermittent MCP tool access:
- Sometimes `list_issues` worked, sometimes it didn't
- `create_pull_request` was never available
- The agent reported "No MCP Server Active" in some sessions

## Solution

### 1. New `verify-mcp.sh` Script

A verification script that runs at container startup to check:
- ✓ MCP configuration exists in `settings.json`
- ✓ GitHub token is present and valid (not expired)
- ✓ Token has correct permissions for target repo
- ✓ Environment variables are set for `gh` CLI compatibility

```bash
# Quick verification
/opt/scripts/verify-mcp.sh

# Verbose output for debugging
GITHUB_DEBUG=1 /opt/scripts/verify-mcp.sh --verbose

# Test access to specific repo
GITHUB_VERIFY_REPO=owner/repo /opt/scripts/verify-mcp.sh
```

### 2. Automatic Verification at Startup

`entrypoint.sh` now runs the verification after GitHub auth setup:
- Runs automatically when `GITHUB_TOKEN` is set
- Shows warnings if verification fails
- Use `GITHUB_DEBUG=1` for verbose output

### 3. Secrets Volume Mount

Added `../secrets:/secrets:ro` to `compose.persistent.yml` to fix GitHub App private key access.

### 4. Updated Troubleshooting Docs

Added comprehensive MCP troubleshooting section to `sandbox-context.md` including:
- How to run verification
- Fallback to `gh` CLI with explicit token
- Common error cases and solutions

## Testing

- [ ] Build image: `make build`
- [ ] Run container with GitHub App credentials
- [ ] Verify MCP verification runs at startup
- [ ] Test verbose mode with `GITHUB_DEBUG=1`

## Related

Addresses issues documented in agent orchestration session logs.