### PR TITLE
fix(mcp): verify-mcp.sh now checks ~/.claude.json for MCP config

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -51,6 +51,12 @@ Use conventional commit types: `fix`, `feat`, `docs`, `ci`, `build`, `chore`, `r
 - Update related checklists when adding new required steps
 - Keep CICD_SETUP.md and SECURITY.md in sync with actual workflows
 
+### Claude Code Configuration
+- MCP servers go in `~/.claude.json` (root config), NOT `~/.claude/settings.json`
+- `~/.claude/settings.json` is for permissions and settings only
+- `GITHUB_PERSONAL_ACCESS_TOKEN` in MCP config is actually a GitHub App installation token
+- This token is for MCP tools ONLY - never extract it for `gh` CLI or other uses
+
 ## Security Mindset
 
 ### Always Consider

--- a/docs/GITHUB_APP_MCP_INTEGRATION.md
+++ b/docs/GITHUB_APP_MCP_INTEGRATION.md
@@ -148,7 +148,15 @@ Generates Claude Code MCP configuration:
 }
 ```
 
-**Note:** The GitHub MCP server uses `GITHUB_PERSONAL_ACCESS_TOKEN` for authentication, but it works with installation tokens despite the name.
+**⚠️ Important about `GITHUB_PERSONAL_ACCESS_TOKEN`:**
+
+Despite its name, this is NOT a personal access token. The GitHub MCP server uses this environment variable name, but we populate it with a **GitHub App installation token**:
+
+- Auto-generated on container startup from GitHub App credentials
+- Expires after ~1 hour (refreshed on container restart)
+- **FOR MCP TOOLS ONLY** - never extract this for `gh` CLI or other uses
+
+The `gh` CLI is not installed in the sandbox. All GitHub operations should use MCP tools, which read this token automatically from `~/.claude.json`.
 
 ### 3. Container Startup (`image/scripts/setup-github-app.sh`)
 


### PR DESCRIPTION
## Summary

Fixes the MCP verification script to check the correct configuration file and updates documentation to clarify the distinction between Claude configuration files.

## Changes

### Bug Fix
- **`image/scripts/verify-mcp.sh`**: Changed to check `~/.claude.json` instead of `~/.claude/settings.json` for MCP server configuration

### Documentation Updates
- **`.cursorrules`**: Added "Claude Code Configuration" section explaining the config file distinction
- **`CLAUDE.md`**: Added Critical Issue #6 explaining the two config files and token usage
- **`image/config/sandbox-context.md`**: Added detailed section about config files and warning about token usage
- **`docs/GITHUB_APP_MCP_INTEGRATION.md`**: Enhanced note about `GITHUB_PERSONAL_ACCESS_TOKEN`

## Key Clarifications

| File | Purpose |
|------|---------|
| `~/.claude.json` | MCP server configuration (`mcpServers`) |
| `~/.claude/settings.json` | Claude Code settings (permissions, auto-updater) |

⚠️ **`GITHUB_PERSONAL_ACCESS_TOKEN`** in MCP config is actually a GitHub App installation token and should **only** be used for MCP tools, never extracted for `gh` CLI.

Fixes #20