### PR TITLE
fix(pool): isolated volumes per worker + skip-permissions flag

### DIFF
--- a/compose/compose.pool.yml
+++ b/compose/compose.pool.yml
@@ -60,9 +60,9 @@ services:
     dns:
       - 10.100.1.2  # dnsfilter
     
-    # Each worker gets its own anonymous volume
+    # Each worker gets its own anonymous volume (not named - anonymous volumes are per-container)
     volumes:
-      - worker_data:/project:rw
+      - /project
       - ../secrets:/secrets:ro
       - ../image/scripts/issue-worker.js:/opt/scripts/issue-worker.js:ro
     
@@ -95,10 +95,6 @@ services:
         condition: service_started
     
     working_dir: /project
-
-volumes:
-  worker_data:
-    # Each scaled instance gets its own volume
 
 networks:
   sandbox_net:

--- a/image/scripts/issue-worker.js
+++ b/image/scripts/issue-worker.js
@@ -296,7 +296,7 @@ When you're done, summarize what you changed.`;
     log(`Running Claude on issue #${issue.number}...`);
     
     return new Promise((resolve) => {
-        const claude = spawn('claude', ['--print', prompt], {
+        const claude = spawn('claude', ['--print', '--dangerously-skip-permissions', prompt], {
             cwd: PROJECT_DIR,
             stdio: ['ignore', 'pipe', 'pipe'],
             env: { ...process.env, TERM: 'dumb' }


### PR DESCRIPTION
## Problem

Pool mode workers were failing because:

1. **Shared volume conflict**: All workers shared the same `worker_data` named volume, causing git clone conflicts when multiple workers tried to clone into the same directory
2. **Permission prompts**: Claude was running without `--dangerously-skip-permissions` flag, causing it to ask for file write permission instead of actually making changes

## Solution

1. Changed `compose.pool.yml` to use anonymous volumes (`/project`) instead of named volumes - each scaled worker now gets its own isolated workspace
2. Added `--dangerously-skip-permissions` flag to Claude invocation in `issue-worker.js`

## Testing

- Deployed 5 workers against `SapphireBeehiveStudios/godot-example`
- Workers successfully cloned repos, processed issues, and created PRs
- 17+ PRs merged, 7+ issues completed

## Files Changed

- `compose/compose.pool.yml` - Use anonymous volumes
- `image/scripts/issue-worker.js` - Add skip-permissions flag